### PR TITLE
Add workaround for git diff issue in perltidy workflow and use updated perl images for all other tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.16'
-          - '5.18'
-          - '5.20'
-          - '5.22'
-          - '5.30'
-          - '5.32'
+          - '5.16-buster'
+          - '5.18-buster'
+          - '5.20-buster'
+          - '5.22-buster'
+          - '5.30-bullseye'
+          - '5.32-bullseye'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: perl -V
         run: perl -V
       - name: Fix ExtUtils::MakeMaker (for Perl 5.16 and 5.18)

--- a/.github/workflows/perltidy.yml
+++ b/.github/workflows/perltidy.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: perl:5.32
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: perl -V
         run: perl -V
       - name: Install dependencies
@@ -23,4 +23,5 @@ jobs:
         shell: bash
         run: |
           shopt -s extglob globstar nullglob
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           perltidy --pro=.../.perltidyrc -b -bext='/' **/*.p[lm] **/*.t && git diff --exit-code

--- a/lib/Mojolicious/Plugin/AssetPack.pm
+++ b/lib/Mojolicious/Plugin/AssetPack.pm
@@ -192,7 +192,7 @@ sub _render_tags {
 
   return Mojo::ByteStream->new(
     join "\n",
-    map    { $_->tag_for->($_, $c, \%args, @attrs) }
+    map { $_->tag_for->($_, $c, \%args, @attrs) }
       grep { !$_->isa('Mojolicious::Plugin::AssetPack::Asset::Null') } @$assets
   );
 }


### PR DESCRIPTION
### Summary
1. Setting the current dir as a safe directory in perltidy workflow to be able to run the git diff command without error: `warning: Not a git repository. Use --no-index to compare two paths outside a working tree ext code`

2. Using Debian tagged perl docker images as the existing perl ones are failing due to using an older format

### Motivation
1. Apparently a security fix in Git made git commands fail, possibly due to different owner of parent directory.

2. Current perl images yield the following error when pulled: `[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/perl:5.14 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
  Error: Docker pull failed with exit code 1`

### References
safe directory issue: https://github.com/actions/checkout/issues/766
perl images issue: https://github.com/briandfoy/cpan-audit/pull/58
